### PR TITLE
custom-action-change-jobid add new end point for custom-action and ch…

### DIFF
--- a/serverless.ts
+++ b/serverless.ts
@@ -23,6 +23,7 @@ import userGenerator from '@functions/userGenerator';
 import newJobChecker from '@functions/newJobChecker';
 import updatedJobChecker from '@functions/updatedJobChecker';
 import jobProcessor from '@functions/jobProcessor';
+import customActionJobChange from '@functions/customActionJobChange';
 
 const serverlessConfiguration: AWS = {
   service: 'smoothstack-careers-api',
@@ -98,6 +99,7 @@ const serverlessConfiguration: AWS = {
     newJobChecker,
     updatedJobChecker,
     jobProcessor,
+    customActionJobChange,
   },
   resources: {
     Conditions: {

--- a/src/functions/customActionJobChange/handler.ts
+++ b/src/functions/customActionJobChange/handler.ts
@@ -1,0 +1,39 @@
+import { middyfy } from '@libs/lambda';
+import { APIGatewayEvent } from 'aws-lambda';
+import { fetchAllJobOrder, updateApplicationJobId } from 'src/service/careers.service';
+import { getSessionData } from 'src/service/auth/bullhorn.oauth.service';
+
+const customActionJobChange = async (event: APIGatewayEvent) => {
+  const method = event.httpMethod.toUpperCase();
+  switch (method) {
+    case 'GET':
+      // Retrieve all the jobs
+      const { restUrl, BhRestToken } = await getSessionData();
+      return await fetchAllJobOrder(restUrl, BhRestToken);
+    case 'PUT':
+      // Update applications to the selected job
+      return await putApplicationJobId(event);
+    default:
+      return {
+        statusCode: 400,
+        body: 'Incorrect HTTP request',
+      };
+  }
+};
+
+const putApplicationJobId = async (event: APIGatewayEvent) => {
+  try {
+    const { restUrl, BhRestToken } = await getSessionData();
+    const { jobId, applicationIds } = event.queryStringParameters;
+    console.log('updating', applicationIds, jobId);
+    return await updateApplicationJobId(+jobId, applicationIds, restUrl, BhRestToken);
+  } catch (e) {
+    console.error('Error updating application job id: ', e);
+    return {
+      statusCode: 500,
+      body: 'Error updating application job id',
+    };
+  }
+};
+
+export const main = middyfy(customActionJobChange);

--- a/src/functions/customActionJobChange/index.ts
+++ b/src/functions/customActionJobChange/index.ts
@@ -1,0 +1,27 @@
+import { handlerPath } from '@libs/handlerResolver';
+
+export default {
+  handler: `${handlerPath(__dirname)}/handler.main`,
+  events: [
+    {
+      http: {
+        method: 'get',
+        path: 'customActionJobChange',
+        cors: {
+          origin: '*',
+          headers: ['Content-Type'],
+        },
+      },
+    },
+    {
+      http: {
+        method: 'put',
+        path: 'customActionJobChange',
+        cors: {
+          origin: '*',
+          headers: ['Content-Type'],
+        },
+      },
+    },
+  ],
+};

--- a/src/service/careers.service.ts
+++ b/src/service/careers.service.ts
@@ -1092,6 +1092,25 @@ export const saveSubmissionChallengeResult = async (
   result === 'Pass' && (await publishLinksGenerationRequest(submissionId, 'techscreen'));
 };
 
+export const fetchAllJobOrder = async (url: string, BhRestToken: string): Promise<JobOrder> => {
+  try {
+    const jobOrdersUrl = `${url}search/JobOrder`;
+    const { data } = await axios.get(jobOrdersUrl, {
+      params: {
+        BhRestToken,
+        fields: 'id,title,isPublic',
+        query: 'isDeleted:0',
+        sort: 'id',
+        count: 100,
+      },
+    });
+    return data.data;
+  } catch (e) {
+    console.error('Error', e);
+    throw e;
+  }
+};
+
 export const fetchJobOrder = async (url: string, BhRestToken: string, jobOrderId: number): Promise<JobOrder> => {
   const jobOrdersUrl = `${url}entity/JobOrder/${jobOrderId}`;
 
@@ -1630,4 +1649,18 @@ export const fetchSubmissionHistoryByAppointmentId = async (
     },
   });
   return data.data;
+};
+
+export const updateApplicationJobId = async (
+  jobId: number,
+  applicationIds: string,
+  url: string,
+  BhRestToken: string
+) => {
+  const applicationIdArray: number[] = applicationIds.split(',').map(Number);
+  const updateData = {
+    jobOrder: { id: jobId },
+  };
+  const requests = applicationIdArray.map((appId: number) => saveSubmissionFields(url, BhRestToken, appId, updateData));
+  return await Promise.all(requests);
 };


### PR DESCRIPTION
This PR is to create a new endpoint for custom new action of changing applications' job id.

1. Get: to retrieve all the available jobs. Because the job list need to include all the published/unpublished jobs so it cannot be retrieve from public api
2. Put: to update all the applications selected on custom-action UI and update jobId to all the applications.